### PR TITLE
lcdmesg / keypad: update to libgpiod 2.x API

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,10 @@ AM_INIT_AUTOMAKE([1.00 foreign no-define])
 # Checks for programs.
 AC_PROG_CC
 
+PKG_CHECK_MODULES([LIBGPIOD], [libgpiod >= 2.2], [], [
+  AC_MSG_ERROR([libgpiod is required but was not found])
+])
+
 # Checks for header files.
 AC_CHECK_HEADERS([fcntl.h stdint.h stdlib.h string.h sys/ioctl.h unistd.h])
 

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,2 +1,5 @@
 *.o
 tshwctl
+keypad
+lcdmesg
+pc104_peekpoke

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,10 +5,10 @@ CFLAGS=-Wall -fno-tree-cselim
 tshwctl_SOURCES = tshwctl.c fpga.c eval_cmdline.c helpers.c
 tshwctl_CPPFLAGS = -DGITCOMMIT="\"${GITCOMMIT}\""
 
-lcdmesg_SOURCES = lcdmesg.c helpers.c fpga.c
+lcdmesg_SOURCES = lcdmesg.c helpers.c fpga.c gpiod-helper.c
 lcdmesg_LDADD = -lgpiod
 
-keypad_SOURCES = keypad.c helpers.c
+keypad_SOURCES = keypad.c helpers.c gpiod-helper.c
 keypad_LDADD = -lgpiod
 
 pc104_peekpoke_SOURCES = pc104_peekpoke.c helpers.c pc104.c

--- a/src/gpiod-helper.c
+++ b/src/gpiod-helper.c
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-FileCopyrightText: 2023 Kent Gibson <warthog618@gmail.com>
+
+#include <errno.h>
+#include <gpiod.h>
+#include <stdio.h>
+
+/* The following helper functions were pulled mostly verbatim from the libgpiod
+ * examples. More information on each function is included in its header.
+ */
+
+/* Request a single line as an input.
+ * Returns struct gpiod_line_request* on success or NULL on failure.
+ * Unfortunately most libgpiod functions don't set errno on failure.
+ *
+ * Pulled from the v2.2.x branch:
+ * https://github.com/brgl/libgpiod/blob/v2.2.x/examples/get_line_value.c
+ */
+struct gpiod_line_request *request_input_line(const char *chip_path,
+					      unsigned int offset,
+					      const char *consumer)
+{
+	struct gpiod_request_config *req_cfg = NULL;
+	struct gpiod_line_request *request = NULL;
+	struct gpiod_line_settings *settings;
+	struct gpiod_line_config *line_cfg;
+	struct gpiod_chip *chip;
+	int ret;
+
+	chip = gpiod_chip_open(chip_path);
+	if (!chip)
+		return NULL;
+
+	settings = gpiod_line_settings_new();
+	if (!settings)
+		goto close_chip;
+
+	gpiod_line_settings_set_direction(settings, GPIOD_LINE_DIRECTION_INPUT);
+
+	line_cfg = gpiod_line_config_new();
+	if (!line_cfg)
+		goto free_settings;
+
+	ret = gpiod_line_config_add_line_settings(line_cfg, &offset, 1,
+						  settings);
+	if (ret)
+		goto free_line_config;
+
+	if (consumer) {
+		req_cfg = gpiod_request_config_new();
+		if (!req_cfg)
+			goto free_line_config;
+
+		gpiod_request_config_set_consumer(req_cfg, consumer);
+	}
+
+	request = gpiod_chip_request_lines(chip, req_cfg, line_cfg);
+
+	gpiod_request_config_free(req_cfg);
+
+free_line_config:
+	gpiod_line_config_free(line_cfg);
+
+free_settings:
+	gpiod_line_settings_free(settings);
+
+close_chip:
+	gpiod_chip_close(chip);
+
+	return request;
+}
+
+
+/* Request a single line as an output.
+ * Returns struct gpiod_line_request* on success or NULL on failure.
+ * Unfortunately most libgpiod functions don't set errno on failure.
+ *
+ * Pulled from the v2.2.x branch:
+ * https://github.com/brgl/libgpiod/blob/v2.2.x/examples/toggle_line_value.c
+ */
+struct gpiod_line_request *
+request_output_line(const char *chip_path, unsigned int offset,
+		    enum gpiod_line_value value, const char *consumer)
+{
+	struct gpiod_request_config *req_cfg = NULL;
+	struct gpiod_line_request *request = NULL;
+	struct gpiod_line_settings *settings;
+	struct gpiod_line_config *line_cfg;
+	struct gpiod_chip *chip;
+	int ret;
+
+	chip = gpiod_chip_open(chip_path);
+	if (!chip)
+		return NULL;
+
+	settings = gpiod_line_settings_new();
+	if (!settings)
+		goto close_chip;
+
+	gpiod_line_settings_set_direction(settings,
+					  GPIOD_LINE_DIRECTION_OUTPUT);
+	gpiod_line_settings_set_output_value(settings, value);
+
+	line_cfg = gpiod_line_config_new();
+	if (!line_cfg)
+		goto free_settings;
+
+	ret = gpiod_line_config_add_line_settings(line_cfg, &offset, 1,
+						  settings);
+	if (ret)
+		goto free_line_config;
+
+	if (consumer) {
+		req_cfg = gpiod_request_config_new();
+		if (!req_cfg)
+			goto free_line_config;
+
+		gpiod_request_config_set_consumer(req_cfg, consumer);
+	}
+
+	request = gpiod_chip_request_lines(chip, req_cfg, line_cfg);
+
+	gpiod_request_config_free(req_cfg);
+
+free_line_config:
+	gpiod_line_config_free(line_cfg);
+
+free_settings:
+	gpiod_line_settings_free(settings);
+
+close_chip:
+	gpiod_chip_close(chip);
+
+	return request;
+}
+
+
+/* Request a single line as a rising edge event
+ * Returns struct gpiod_line_request* on success or NULL on failure.
+ * Unfortunately most libgpiod functions don't set errno on failure.
+ *
+ * Pulled from the v2.2.x branch:
+ * https://github.com/brgl/libgpiod/blob/v2.2.x/examples/watch_line_rising.c
+ */
+struct gpiod_line_request *request_input_line_rising(const char *chip_path,
+						     unsigned int offset,
+						     const char *consumer)
+{
+	struct gpiod_request_config *req_cfg = NULL;
+	struct gpiod_line_request *request = NULL;
+	struct gpiod_line_settings *settings;
+	struct gpiod_line_config *line_cfg;
+	struct gpiod_chip *chip;
+	int ret;
+
+	chip = gpiod_chip_open(chip_path);
+	if (!chip)
+		return NULL;
+
+	settings = gpiod_line_settings_new();
+	if (!settings)
+		goto close_chip;
+
+	gpiod_line_settings_set_direction(settings, GPIOD_LINE_DIRECTION_INPUT);
+	gpiod_line_settings_set_edge_detection(settings, GPIOD_LINE_EDGE_RISING);
+
+	line_cfg = gpiod_line_config_new();
+	if (!line_cfg)
+		goto free_settings;
+
+	ret = gpiod_line_config_add_line_settings(line_cfg, &offset, 1,
+						  settings);
+	if (ret)
+		goto free_line_config;
+
+	if (consumer) {
+		req_cfg = gpiod_request_config_new();
+		if (!req_cfg)
+			goto free_line_config;
+
+		gpiod_request_config_set_consumer(req_cfg, consumer);
+	}
+
+	request = gpiod_chip_request_lines(chip, req_cfg, line_cfg);
+
+	gpiod_request_config_free(req_cfg);
+
+free_line_config:
+	gpiod_line_config_free(line_cfg);
+
+free_settings:
+	gpiod_line_settings_free(settings);
+
+close_chip:
+	gpiod_chip_close(chip);
+
+	return request;
+}
+
+/* Request multiple lines as output
+ * Returns struct gpiod_line_request* on success or NULL on failure.
+ * Unfortunately most libgpiod functions don't set errno on failure.
+ *
+ * Pulled from the v2.2.x branch:
+ * https://github.com/brgl/libgpiod/blob/v2.2.x/examples/toggle_multiple_line_values.c
+ */
+struct gpiod_line_request *
+request_output_lines(const char *chip_path, const unsigned int *offsets,
+		     enum gpiod_line_value *values, unsigned int num_lines,
+		     const char *consumer)
+{
+	struct gpiod_request_config *rconfig = NULL;
+	struct gpiod_line_request *request = NULL;
+	struct gpiod_line_settings *settings;
+	struct gpiod_line_config *lconfig;
+	struct gpiod_chip *chip;
+	unsigned int i;
+	int ret;
+
+	chip = gpiod_chip_open(chip_path);
+	if (!chip)
+		return NULL;
+
+	settings = gpiod_line_settings_new();
+	if (!settings)
+		goto close_chip;
+
+	gpiod_line_settings_set_direction(settings,
+					  GPIOD_LINE_DIRECTION_OUTPUT);
+
+	lconfig = gpiod_line_config_new();
+	if (!lconfig)
+		goto free_settings;
+
+	for (i = 0; i < num_lines; i++) {
+		ret = gpiod_line_config_add_line_settings(lconfig, &offsets[i],
+							  1, settings);
+		if (ret)
+			goto free_line_config;
+	}
+	gpiod_line_config_set_output_values(lconfig, values, num_lines);
+
+	if (consumer) {
+		rconfig = gpiod_request_config_new();
+		if (!rconfig)
+			goto free_line_config;
+
+		gpiod_request_config_set_consumer(rconfig, consumer);
+	}
+
+	request = gpiod_chip_request_lines(chip, rconfig, lconfig);
+
+	gpiod_request_config_free(rconfig);
+
+free_line_config:
+	gpiod_line_config_free(lconfig);
+
+free_settings:
+	gpiod_line_settings_free(settings);
+
+close_chip:
+	gpiod_chip_close(chip);
+
+	return request;
+}
+
+/* Request multiple lines as input
+ * Returns struct gpiod_line_request* on success or NULL on failure.
+ * Unfortunately most libgpiod functions don't set errno on failure.
+ *
+ * Pulled from the v2.2.x branch:
+ * https://github.com/brgl/libgpiod/blob/v2.2.x/examples/get_multiple_line_values.c
+ */
+struct gpiod_line_request *
+request_input_lines(const char *chip_path, const unsigned int *offsets,
+		    unsigned int num_lines, const char *consumer)
+{
+	struct gpiod_request_config *req_cfg = NULL;
+	struct gpiod_line_request *request = NULL;
+	struct gpiod_line_settings *settings;
+	struct gpiod_line_config *line_cfg;
+	struct gpiod_chip *chip;
+	unsigned int i;
+	int ret;
+
+	chip = gpiod_chip_open(chip_path);
+	if (!chip)
+		return NULL;
+
+	settings = gpiod_line_settings_new();
+	if (!settings)
+		goto close_chip;
+
+	gpiod_line_settings_set_direction(settings, GPIOD_LINE_DIRECTION_INPUT);
+
+	line_cfg = gpiod_line_config_new();
+	if (!line_cfg)
+		goto free_settings;
+
+	for (i = 0; i < num_lines; i++) {
+		ret = gpiod_line_config_add_line_settings(line_cfg, &offsets[i],
+							  1, settings);
+		if (ret)
+			goto free_line_config;
+	}
+
+	if (consumer) {
+		req_cfg = gpiod_request_config_new();
+		if (!req_cfg)
+			goto free_line_config;
+
+		gpiod_request_config_set_consumer(req_cfg, consumer);
+	}
+
+	request = gpiod_chip_request_lines(chip, req_cfg, line_cfg);
+
+	gpiod_request_config_free(req_cfg);
+
+free_line_config:
+	gpiod_line_config_free(line_cfg);
+
+free_settings:
+	gpiod_line_settings_free(settings);
+
+close_chip:
+	gpiod_chip_close(chip);
+
+	return request;
+}
+

--- a/src/gpiod-helper.h
+++ b/src/gpiod-helper.h
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-FileCopyrightText: 2023 Kent Gibson <warthog618@gmail.com>
+
+/* The following helper functions were pulled mostly verbatim from the libgpiod
+ * examples. More information on each function is included in its header.
+ */
+
+#pragma once
+
+#include <gpiod.h>
+#include <stdio.h>
+
+/* Request a single line as an input.
+ * Returns struct gpiod_line_request* on success or NULL on failure.
+ * Unfortunately most libgpiod functions don't set errno on failure.
+ *
+ * Pulled from the v2.2.x branch:
+ * https://github.com/brgl/libgpiod/blob/v2.2.x/examples/get_line_value.c
+ */
+
+struct gpiod_line_request *request_input_line(const char *chip_path,
+					      unsigned int offset,
+					      const char *consumer);
+
+/* Request a single line as an output.
+ * Returns struct gpiod_line_request* on success or NULL on failure.
+ * Unfortunately most libgpiod functions don't set errno on failure.
+ *
+ * Pulled from the v2.2.x branch:
+ * https://github.com/brgl/libgpiod/blob/v2.2.x/examples/toggle_line_value.c
+ */
+struct gpiod_line_request *
+request_output_line(const char *chip_path, unsigned int offset,
+		    enum gpiod_line_value value, const char *consumer);
+
+/* Request a single line as a rising edge event
+ * Returns struct gpiod_line_request* on success or NULL on failure.
+ * Unfortunately most libgpiod functions don't set errno on failure.
+ *
+ * Pulled from the v2.2.x branch:
+ * https://github.com/brgl/libgpiod/blob/v2.2.x/examples/watch_line_rising.c
+ */
+struct gpiod_line_request *request_input_line_rising(const char *chip_path,
+						     unsigned int offset,
+						     const char *consumer);
+
+/* Request multiple lines as output
+ * Returns struct gpiod_line_request* on success or NULL on failure.
+ * Unfortunately most libgpiod functions don't set errno on failure.
+ *
+ * Pulled from the v2.2.x branch:
+ * https://github.com/brgl/libgpiod/blob/v2.2.x/examples/toggle_multiple_line_values.c
+ */
+struct gpiod_line_request *
+request_output_lines(const char *chip_path, const unsigned int *offsets,
+		     enum gpiod_line_value *values, unsigned int num_lines,
+		     const char *consumer);
+
+/* Request multiple lines as input
+ * Returns struct gpiod_line_request* on success or NULL on failure.
+ * Unfortunately most libgpiod functions don't set errno on failure.
+ *
+ * Pulled from the v2.2.x branch:
+ * https://github.com/brgl/libgpiod/blob/v2.2.x/examples/get_multiple_line_values.c
+ */
+struct gpiod_line_request *
+request_input_lines(const char *chip_path, const unsigned int *offsets,
+		    unsigned int num_lines, const char *consumer);

--- a/src/keypad.c
+++ b/src/keypad.c
@@ -5,11 +5,9 @@
 #include <unistd.h>
 #include <assert.h>
 #include <sys/time.h>
-#include "helpers.h"
 
-struct gpiod_chip *chip;
-struct gpiod_line_bulk dout;
-struct gpiod_line_bulk din;
+#include "gpiod-helper.h"
+#include "helpers.h"
 
 const char *key_label[16] = {
 	"1", "2", "3", "UP",
@@ -18,27 +16,32 @@ const char *key_label[16] = {
 	"CLEAR", "0", "HELP", "ENTER",
 };
 
-void set_4bit_array(int *val, uint8_t data)
+void set_4bit_array(enum gpiod_line_value *val, uint8_t data)
 {
-	val[0] = data & (1 << 0);
-	val[1] = data & (1 << 1);
-	val[2] = data & (1 << 2);
-	val[3] = data & (1 << 3);
+	const enum gpiod_line_value values[2] = {GPIOD_LINE_VALUE_INACTIVE,
+						 GPIOD_LINE_VALUE_ACTIVE};
+	int i;
+
+	for (i = 0; i < 4; i++) {
+		val[i] = values[!!(data & (1 << i))];
+	}
 }
 
-void scan_keypad(uint8_t *keys)
+void scan_keypad(struct gpiod_line_request *dout,
+		 struct gpiod_line_request *din,
+		 uint8_t *keys)
 {
 	int key;
-	int lines[4];
+	enum gpiod_line_value lines[4] = {GPIOD_LINE_VALUE_INACTIVE};
 	int r;
 	uint8_t row, col;
 	memset(keys, 0, 16);
 
 	for (row = 0; row < 4; row++) {
 		set_4bit_array(lines, ~(1 << row));
-		r = gpiod_line_set_value_bulk(&dout, lines);
+		r = gpiod_line_request_set_values(dout, lines);
 		assert (!r);
-		r = gpiod_line_get_value_bulk(&din, lines);
+		r = gpiod_line_request_get_values(din, lines);
 		assert (!r);
 		for (col = 0; col < 4; col++) {
 			key = (row * 4) + col;
@@ -81,32 +84,34 @@ void debounce_keypad(uint8_t *keys, uint8_t *debounced)
 
 int main()
 {
-	int ret, i;
+	int i;
 	unsigned int out_pins[4] = {1, 2, 3, 4};
 	unsigned int in_pins[4] = {6, 7, 8, 9};
-	uint8_t keys[16], debounced[16], oldstate[16];
-	memset(oldstate, 0, 16);
+	struct gpiod_line_request *dout;
+	struct gpiod_line_request *din;
+	enum gpiod_line_value value_init[4] = {GPIOD_LINE_VALUE_ACTIVE};
+	uint8_t keys[16] = {0};
+	uint8_t debounced[16] = {0};
+	uint8_t oldstate[16] = {0};
 
 	if(get_model() != 0x7250) {
 		fprintf(stderr, "This is only supported on the TS-7250-V3\n");
 		return 1;
 	}
 
-	chip = gpiod_chip_open_by_number(5);
-	assert(chip);
-	gpiod_line_bulk_init(&dout);
-	gpiod_line_bulk_init(&din);
-	ret = gpiod_chip_get_lines(chip, out_pins, 4, &dout);
-	assert(!ret);
-	ret = gpiod_chip_get_lines(chip, in_pins, 4, &din);
-	assert(!ret);
-	ret = gpiod_line_request_bulk_output(&dout, "keypad rows", NULL);
-	assert(!ret);
-	ret = gpiod_line_request_bulk_input(&din, "keypad cols");
-	assert(!ret);
+	dout = request_output_lines("/dev/gpiochip5",
+				    out_pins,
+				    value_init,
+				    4,
+				    "keypad rows");
 
+	din = request_input_lines("/dev/gpiochip5",
+				   in_pins,
+				   4,
+				   "keypad cols");
+				    
 	while(1) {
-		scan_keypad(keys);
+		scan_keypad(dout, din, keys);
 		debounce_keypad(keys, debounced);
 		for (i = 0; i < 16; i++) {
 			if(keys[i] && oldstate[i])

--- a/src/lcdmesg.c
+++ b/src/lcdmesg.c
@@ -10,6 +10,8 @@
 #include <assert.h>
 #include <time.h>
 #include <unistd.h>
+
+#include "gpiod-helper.h"
 #include "helpers.h"
 #include "fpga.h"
 
@@ -18,26 +20,26 @@
 uint16_t lcd_bias_value;
 
 struct hd44780 {
-	struct gpiod_chip *chip;
-	struct gpiod_line_bulk data;
-	struct gpiod_line *en;
-	struct gpiod_line *rs;
-	struct gpiod_line *wr;
+	struct gpiod_line_request *data;
+	struct gpiod_line_request *en;
+	struct gpiod_line_request *rs;
+	struct gpiod_line_request *wr;
 };
 
-void set_8bit_array(int *val, uint8_t data)
+static void set_8bit_array(enum gpiod_line_value *val, uint8_t data)
 {
-	val[0] = data & (1 << 0);
-	val[1] = data & (1 << 1);
-	val[2] = data & (1 << 2);
-	val[3] = data & (1 << 3);
-	val[4] = data & (1 << 4);
-	val[5] = data & (1 << 5);
-	val[6] = data & (1 << 6);
-	val[7] = data & (1 << 7);
+	const enum gpiod_line_value values[2] = {
+				GPIOD_LINE_VALUE_INACTIVE,
+				GPIOD_LINE_VALUE_ACTIVE};
+
+	int i;
+
+	for (i = 0; i < 8; i++) {
+		val[i] = values[!!(data & (1 << i))];
+	}
 }
 
-void nsleep(long int nsec)
+static void nsleep(long int nsec)
 {
 	struct timespec target, leftover;
 	int ret;
@@ -50,34 +52,32 @@ void nsleep(long int nsec)
 		if (errno == -EINTR)
 			nsleep(leftover.tv_nsec);
 }
-uint8_t get_8bit_array(int *val)
+
+static void gpiod_line_request_set_helper(struct gpiod_line_request *line,
+					  int offs,
+					  uint8_t val)
 {
-	uint8_t ret;
-	ret = (val[0] << 0);
-	ret |= (val[1] << 1);
-	ret |= (val[2] << 2);
-	ret |= (val[3] << 3);
-	ret |= (val[4] << 4);
-	ret |= (val[5] << 5);
-	ret |= (val[6] << 6);
-	ret |= (val[7] << 7);
-	return ret;
+	enum gpiod_line_value new_val = (!!val ?
+					 GPIOD_LINE_VALUE_ACTIVE :
+					 GPIOD_LINE_VALUE_INACTIVE);
+
+	gpiod_line_request_set_value(line, offs, new_val);
 }
 
 /* https://www.sparkfun.com/datasheets/LCD/HD44780.pdf
  * Sheet 58 */
-void lcd_write(struct hd44780 *lcd, uint8_t rs, uint8_t data)
+static void lcd_write(struct hd44780 *lcd, uint8_t rs, uint8_t data)
 {
-	int val[8];
+	enum gpiod_line_value val[8];
 	set_8bit_array(val, data);
 
-	gpiod_line_set_value(lcd->rs, rs);
-	gpiod_line_set_value(lcd->wr, 0);
-	gpiod_line_set_value_bulk(&lcd->data, val);
+	gpiod_line_request_set_helper(lcd->rs, 21, rs);
+	gpiod_line_request_set_helper(lcd->wr, 19, 0);
+	gpiod_line_request_set_values(lcd->data, val);
 	nsleep(60); /* tAS */
-	gpiod_line_set_value(lcd->en, 1);
+	gpiod_line_request_set_helper(lcd->en, 20, 1);
 	nsleep(230); /* PWEH */
-	gpiod_line_set_value(lcd->en, 0);
+	gpiod_line_request_set_helper(lcd->en, 20, 0);
 	nsleep(210); /* tH/tAH + tcycE */
 
 	usleep(37);
@@ -85,18 +85,18 @@ void lcd_write(struct hd44780 *lcd, uint8_t rs, uint8_t data)
 
 /* Set a contrast (duty cycle) from 0 (off) to 15 (max).
  * This may need to change depending on the LCD used or the altitude */
-void lcd_contrast(uint8_t duty)
+static void lcd_contrast(uint8_t duty)
 {
 	fpoke32(0x1c, duty & 0xf);
 }
 
-void lcd_writechars(struct hd44780 *lcd, char *dat)
+static void lcd_writechars(struct hd44780 *lcd, char *dat)
 {
 	while(*dat)
 		lcd_write(lcd, 1, *dat++);
 }
 
-void lcd_returnhome(struct hd44780 *lcd)
+static void lcd_returnhome(struct hd44780 *lcd)
 {
 	/* Since we cannot poll busy, the write function waits the typical 37us
 	 * execution time max.  Clear home must wait 1.52ms, but all other
@@ -106,39 +106,45 @@ void lcd_returnhome(struct hd44780 *lcd)
 	usleep(1520);
 }
 
-void lcd_init(struct hd44780 *lcd)
+static void lcd_init(struct hd44780 *lcd)
 {
-	int ret;
 	int model;
+	unsigned int datapins[8] = {10, 9, 12, 11, 16, 15, 18, 17};
+	enum gpiod_line_value value_init[8] = {GPIOD_LINE_VALUE_ACTIVE};
 
 	model = get_model();
-	if(model == 0x7250){
-		unsigned int datapins[8] = {10, 9, 12, 11, 16, 15, 18, 17};
-
-		lcd->chip = gpiod_chip_open_by_number(2);
-		assert(lcd->chip);
-		gpiod_line_bulk_init(&lcd->data);
-		ret = gpiod_chip_get_lines(lcd->chip, datapins, 8, &lcd->data);
-		assert(!ret);
-		lcd->en = gpiod_chip_get_line(lcd->chip, 20);
-		assert(lcd->en);
-		lcd->rs = gpiod_chip_get_line(lcd->chip, 21);
-		assert(lcd->rs);
-		lcd->wr = gpiod_chip_get_line(lcd->chip, 19);
-		assert(lcd->wr);
-	} else {
+	if(model != 0x7250){
 		fprintf(stderr, "Unsupported model 0x%X\n", model);
 		exit(1);
 	}
 
-	fpga_init(0x50004000);
+	lcd->data = request_output_lines("/dev/gpiochip2",
+					 datapins,
+					 value_init,
+					 8,
+					 CONSUMER);
+	lcd->en = request_output_line("/dev/gpiochip2",
+				      20,
+				      GPIOD_LINE_VALUE_ACTIVE,
+				      CONSUMER);
+	lcd->rs = request_output_line("/dev/gpiochip2",
+				      21,
+				      GPIOD_LINE_VALUE_ACTIVE,
+				      CONSUMER);
+	lcd->wr = request_output_line("/dev/gpiochip2",
+				      19,
+				      GPIOD_LINE_VALUE_ACTIVE,
+				      CONSUMER);
 
-	/* Initialize all IO as high */
-	ret = gpiod_line_request_bulk_output(&lcd->data, CONSUMER, NULL);
-	ret |= gpiod_line_request_output(lcd->en, CONSUMER, 1);
-	ret |= gpiod_line_request_output(lcd->rs, CONSUMER, 1);
-	ret |= gpiod_line_request_output(lcd->wr, CONSUMER, 1);
-	assert(!ret);
+	if (lcd->data == NULL ||
+	    lcd->en == NULL ||
+	    lcd->rs == NULL ||
+	    lcd->wr == NULL) {
+		fprintf(stderr, "Unable to open GPIO lines\n");
+		exit(1);
+	}
+
+	fpga_init(0x50004000);
 
 	/* Recover from any potential state to 8-bit mode, and set:
 	 * Function Set

--- a/src/pc104.c
+++ b/src/pc104.c
@@ -230,6 +230,8 @@ static inline uint32_t get_reg(ucontext_t *ctx, uint8_t rd) {
 	case 14: return ctx->uc_mcontext.arm_lr;
 	case 15: return ctx->uc_mcontext.arm_pc;
 	}
+
+	return 0;
 }
 
 static void fault(int signum, siginfo_t *info, void *vcontext) {
@@ -302,14 +304,15 @@ void *pc104_mmap_init() {
 	    sigaction(SIGBUS, &act, NULL) == -1) {
 		const int retval = errno;
 		fprintf(stderr, "Cannot install fault signal handlers: %s.\n",
-		strerror(retval));
+			strerror(retval));
 		return NULL;
 	}
 
 	bus_space = mmap(NULL, bus_space_sz, PROT_NONE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
 	if (bus_space == MAP_FAILED) {
 		const int retval = errno;
-		fprintf(stderr, "Unable to create fault address space\n");
+		fprintf(stderr, "Unable to create fault address space: %s.\n",
+			strerror(retval));
 		return NULL;
 	}
 	return bus_space;


### PR DESCRIPTION
Update to use libgpiod 2.x API, fixes #7 

Tested against:
- TS-7250-V3 Rev. C (keypad manually tested with wires against pre- and post-libgpiod 2.x updates)


This should be considered a major rev bump of `ts7100-utils`. Support for this in https://github.com/embeddedTS/buildroot-ts needs move to libgpiod2. Similar for https://github.com/embeddedTS/meta-ts/ needs to be updated and then the limit of prefer libgpiod 1.x removed.